### PR TITLE
Override the portal meta-data during server (re)start to create Blog pages

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/conf/portal-pages.xml
+++ b/webapp/src/main/webapp/WEB-INF/conf/portal-pages.xml
@@ -13,6 +13,10 @@
 			<type>org.exoplatform.portal.config.NewPortalConfigListener</type>
 			<description>this listener init the portal configuration</description>
 			<init-params>
+				<value-param>
+					<name>override</name>
+					<value>true</value>
+				</value-param>
 				<object-param>
 					<name>portal.configuration</name>
 					<description>description</description>


### PR DESCRIPTION
Problem:
- When blog addon is deployed on a non-fresh Platform, there isn't either Blog page or Blog Admin page.

Fix description:
- Set override to true into initial parameters of NewPortalConfigListener.
